### PR TITLE
fix: use wasm-pack instead of wasm-bindgen-cli

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -28,17 +28,11 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Add WASM target
-        run: rustup target add wasm32-unknown-unknown
-
-      - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli
+      - name: Install wasm-pack
+        run: cargo install wasm-pack
 
       - name: Build WASM
-        run: |
-          cargo build -p jpp_wasm --target wasm32-unknown-unknown --release
-          wasm-bindgen --target web --out-dir web/wasm \
-            target/wasm32-unknown-unknown/release/jpp_wasm.wasm
+        run: wasm-pack build crates/jpp_wasm --target web --out-dir ../../web/wasm --release
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -28,8 +28,24 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Cache Cargo
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Install wasm-pack
-        run: cargo install wasm-pack
+        run: |
+          if ! command -v wasm-pack >/dev/null 2>&1; then
+            cargo install wasm-pack
+          fi
 
       - name: Build WASM
         run: wasm-pack build crates/jpp_wasm --target web --out-dir ../../web/wasm --release

--- a/crates/jpp_wasm/Cargo.toml
+++ b/crates/jpp_wasm/Cargo.toml
@@ -15,3 +15,6 @@ serde_json = "1"
 
 [lints]
 workspace = true
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ["-O", "--enable-bulk-memory", "--enable-nontrapping-float-to-int"]

--- a/justfile
+++ b/justfile
@@ -29,9 +29,7 @@ setup:
   cargo install cargo-llvm-cov --locked
 
 wasm-build:
-  cargo build -p jpp_wasm --target wasm32-unknown-unknown --release
-  wasm-bindgen --target web --out-dir web/wasm \
-    target/wasm32-unknown-unknown/release/jpp_wasm.wasm
+  wasm-pack build crates/jpp_wasm --target web --out-dir ../../web/wasm --release
 
 web-dev: wasm-build
   cd web && bun install && bunx --bun vite --host


### PR DESCRIPTION
## Summary

Replace wasm-bindgen-cli with wasm-pack to fix version mismatch issues.

## Problem

After committing Cargo.lock, deploy-web workflow failed due to wasm-bindgen version mismatch:
- Cargo.lock pins wasm-bindgen to 0.2.106
- `cargo install wasm-bindgen-cli` installs latest (0.2.108)

## Solution

Use wasm-pack instead, which automatically downloads the correct wasm-bindgen-cli version matching the project's Cargo.lock.

## Changes

- `deploy-web.yml`: Replace wasm-bindgen-cli with wasm-pack
- `crates/jpp_wasm/Cargo.toml`: Add wasm-opt flags for Rust 1.82+ compatibility
- `justfile`: Update wasm-build command to use wasm-pack